### PR TITLE
Add recipe and resource to configure CloudStack using Marvin

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,26 @@ cloudstack_global_setting "expunge.delay" do
 end
 ```
 
+### cloudstack_configure_cloud
+
+Configure cloudstack infrastructure using CloudStack Marvin. A Marvin configuration template file must be provided.
+
+#### examples
+
+``` ruby
+cloudstack_configure_cloud "/vagrant/marvin.cfg" do
+  database_server_ip node['cloudstack']['db']['host']
+end
+```
+
+``` ruby
+cloudstack_configure_cloud node['cloudstack']['configuration'] do
+  database_server_ip node['cloudstack']['db']['host']
+  database_user node['cloudstack']['db']['user']
+  database_password node['cloudstack']['db']['password']
+end
+```
+
 
 Recipes
 -------

--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ MySQL tunning based on official CloudStack documentation.
 
 Configure CloudStack to send Events into RabbitMQ message bus. Work for CloudStack 4.3 and latest. RabbitMQ must be installed and configured somewhere, default values are for localhost.
 
+### cloudstack::marvin
+
+Install CloudStack Marvin (python program used to automate CloudStack infrastructure configuration).
 
 ### cloudstack::default
 

--- a/providers/configure_cloud.rb
+++ b/providers/configure_cloud.rb
@@ -1,0 +1,75 @@
+#
+# Cookbook Name:: marvin
+# provider:: configure cloud
+# Author:: Ian Duffy (<ian@ianduffy.ie>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include Cloudstack
+
+# Support whyrun
+def whyrun_supported?
+  true
+end
+
+action :run do
+  if ::File.exists?(new_resource.name)
+    wait_count = 0
+    until cloudstack_api_is_running? or wait_count == 5 do
+      cloudstack_api_is_running?
+      sleep(5)
+      wait_count +=1
+      if wait_count == 1
+        Chef::Log.info 'Waiting CloudStack to start'
+      end
+    end
+
+    if cloudstack_api_is_running?
+
+      template '/tmp/marvin.cfg' do
+        source new_resource.name
+        local true
+        variables(
+            :management_server_ip => new_resource.management_server_ip,
+            :management_server_port => new_resource.management_server_port,
+            :admin_apikey => new_resource.admin_apikey,
+            :admin_secretkey => new_resource.admin_secretkey,
+            :database_server_ip => new_resource.database_server_ip,
+            :database_server_port => new_resource.database_server_port,
+            :database_user => new_resource.database_user,
+            :database_password => new_resource.database_password,
+            :database => new_resource.database
+        )
+      end
+
+      bash 'Configuring the cloud' do
+        code 'python -m marvin.deployDataCenter -i /tmp/marvin.cfg || true'
+      end
+    end
+  end
+end
+
+def load_current_resource
+  @current_resource = Chef::Resource::CloudstackConfigureCloud.new(@new_resource.name)
+  @current_resource.name(@new_resource.name)
+  @current_resource.management_server_ip(@new_resource.management_server_ip)
+  @current_resource.management_server_port(@new_resource.management_server_port)
+  @current_resource.admin_apikey(@new_resource.admin_apikey)
+  @current_resource.admin_secretkey(@new_resource.admin_secretkey)
+  @current_resource.database_server_ip(@new_resource.database_server_ip)
+  @current_resource.database_server_port(@new_resource.database_server_port)
+  @current_resource.database_user(@new_resource.database_user)
+  @current_resource.database_password(@new_resource.database_password)
+  @current_resource.database(@new_resource.database)
+end

--- a/providers/configure_cloud.rb
+++ b/providers/configure_cloud.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: marvin
+# Cookbook Name:: cloudstack
 # provider:: configure cloud
 # Author:: Ian Duffy (<ian@ianduffy.ie>)
 #
@@ -16,12 +16,14 @@
 # limitations under the License.
 #
 
-include Cloudstack
+include Cloudstack::Helper
 
 # Support whyrun
 def whyrun_supported?
   true
 end
+
+use_inline_resources
 
 action :run do
   if ::File.exists?(new_resource.name)
@@ -37,7 +39,7 @@ action :run do
 
     if cloudstack_api_is_running?
 
-      template '/tmp/marvin.cfg' do
+      template "#{Chef::Config[:file_cache_path]}/marvin.cfg" do
         source new_resource.name
         local true
         variables(
@@ -54,7 +56,7 @@ action :run do
       end
 
       bash 'Configuring the cloud' do
-        code 'python -m marvin.deployDataCenter -i /tmp/marvin.cfg || true'
+        code "python -m marvin.deployDataCenter -i #{Chef::Config[:file_cache_path]}/marvin.cfg || true"
       end
     end
   end

--- a/recipes/marvin.rb
+++ b/recipes/marvin.rb
@@ -1,0 +1,42 @@
+#
+# Cookbook Name:: cloudstack
+# Recipe:: marvin
+# Author:: Olivier Lemasle (<olivier.lemasle@apalia.net>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# When marvin will be available from DEB/RPM packages, we will use it instead of pip.
+# That's why we're not using the "poise-python" cookbook.
+
+case node['platform_family']
+when 'debian'
+  package ['python-dev', 'build-essential', 'python-pip', 'libffi-dev', 'libssl-dev']
+
+when 'rhel'
+  package ['python-devel', 'gcc', 'libffi-devel', 'openssl-devel']
+
+  remote_file "#{Chef::Config[:file_cache_path]}/get-pip.py" do
+    source 'https://bootstrap.pypa.io/get-pip.py'
+  end
+  bash 'Install Python pip' do
+    code "python #{Chef::Config[:file_cache_path]}/get-pip.py"
+  end
+end
+
+bash 'Install mysql-connector-python and cloudstack-marvin' do
+  code <<-EOH
+      pip install --user --upgrade http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.zip#md5=3df394d89300db95163f17c843ef49df
+      pip install --user --upgrade cloudstack-marvin
+  EOH
+end

--- a/resources/configure_cloud.rb
+++ b/resources/configure_cloud.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: marvin
+# Cookbook Name:: cloudstack
 # resource:: configure cloud
 # Author:: Ian Duffy (<ian@ianduffy.ie>)
 #

--- a/resources/configure_cloud.rb
+++ b/resources/configure_cloud.rb
@@ -1,0 +1,35 @@
+#
+# Cookbook Name:: marvin
+# resource:: configure cloud
+# Author:: Ian Duffy (<ian@ianduffy.ie>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+actions :run
+
+default_action :run
+
+attribute :name, :name_attribute => true, :kind_of => String
+attribute :management_server_ip, :kind_of => String, :default => node['ipaddress']
+attribute :management_server_port, :kind_of => Integer, :default => 8096
+attribute :admin_apikey, :kind_of => String
+attribute :admin_secretkey, :kind_of => String
+attribute :database_server_ip, :kind_of => String, :default => '127.0.0.1'
+attribute :database_server_port, :kind_of => Integer, :default => 3306
+attribute :database_user, :kind_of => String, :default => 'cloud'
+attribute :database_password, :kind_of => String, :default => 'password'
+attribute :database, :kind_of => String, :default => 'cloud'
+
+attr_accessor :exists


### PR DESCRIPTION
This pull requests adds resource `cloudstack_configure_cloud` from @imduffy15's fork https://github.com/imduffy15/cookbook_cloudstack-1.

I've also added a new recipe `cloudstack::marvin` (@imduffy15's one do not work anymore due to MySQL connector being unavailable). The content of this recipe is temporary, because in next CloudStack version, Marvin will be provided as a DEB/RPM package, so it will be easier to install it using packages.

@pdion891 As your CloudStack cookbook is up-to-date and is already published on Chef Supermarket, I found it better to add this interesting "marvin" feature to it.

@imduffy15 I hope you don't mind!
