### PR TITLE
Enhance cloudstack repo recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ cloudstack CHANGELOG
 
 This file is used to list changes made in each version of the co-cloudstack cookbook.
 
+4.1.2
+-----
+- khos2ow - add default metadata expire to cloudstack repo
+
 4.1.1
 -----
 - khos2ow - add server-id for mysql

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ cloudstack CHANGELOG
 
 This file is used to list changes made in each version of the co-cloudstack cookbook.
 
+4.1.0
+-----
+- khos2ow - add support for enabling/disabling cloudstack repo
+
 4.0.7
 -----
 - pdion891 - add support for CentOS 7 for ACS 4.10 with JDK8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ cloudstack CHANGELOG
 
 This file is used to list changes made in each version of the co-cloudstack cookbook.
 
+4.1.1
+-----
+- khos2ow - add server-id for mysql
+
 4.1.0
 -----
 - khos2ow - add support for enabling/disabling cloudstack repo

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,6 +34,7 @@ when 'centos', 'redhat', 'fedora', 'oracle'
   default['cloudstack']['repo_url']  = "http://cloudstack.apt-get.eu/centos/$releasever/#{node['cloudstack']['release_major']}/"
   default['cloudstack']['repo_sign'] = ''
   #default['cloudstack']['repo_sign'] = 'http://cloudstack.apt-get.eu/RPM-GPG-KEY'
+  default['cloudstack']['repo_enabled'] = true
 when 'ubuntu', 'debian'
   default['cloudstack']['repo_url']  = "http://cloudstack.apt-get.eu/ubuntu"
   default['cloudstack']['repo_sign'] = 'http://cloudstack.apt-get.eu/release.asc'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ when 'centos', 'redhat', 'fedora', 'oracle'
   default['cloudstack']['repo_sign'] = ''
   #default['cloudstack']['repo_sign'] = 'http://cloudstack.apt-get.eu/RPM-GPG-KEY'
   default['cloudstack']['repo_enabled'] = true
+  default['cloudstack']['repo_metadata_expire'] = '6h'
 when 'ubuntu', 'debian'
   default['cloudstack']['repo_url']  = "http://cloudstack.apt-get.eu/ubuntu"
   default['cloudstack']['repo_sign'] = 'http://cloudstack.apt-get.eu/release.asc'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'pdion@cloudops.com'
 license          'Apache 2.0'
 description      'Installs/Configures cloudstack'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '4.1.1'
+version          '4.1.2'
 
 source_url 'https://github.com/cloudops/cookbook_cloudstack'
 issues_url 'https://github.com/cloudops/cookbook_cloudstack/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'pdion@cloudops.com'
 license          'Apache 2.0'
 description      'Installs/Configures cloudstack'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '4.0.7'
+version          '4.1.0'
 
 source_url 'https://github.com/cloudops/cookbook_cloudstack'
 issues_url 'https://github.com/cloudops/cookbook_cloudstack/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'pdion@cloudops.com'
 license          'Apache 2.0'
 description      'Installs/Configures cloudstack'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '4.1.0'
+version          '4.1.1'
 
 source_url 'https://github.com/cloudops/cookbook_cloudstack'
 issues_url 'https://github.com/cloudops/cookbook_cloudstack/issues'

--- a/recipes/repo_rhel.rb
+++ b/recipes/repo_rhel.rb
@@ -23,6 +23,7 @@ yum_repository 'cloudstack' do
   description 'Apache Cloudstack'
   baseurl node['cloudstack']['repo_url']
   enabled node['cloudstack']['repo_enabled']
+  metadata_expire node['cloudstack']['repo_metadata_expire']
   gpgkey node['cloudstack']['repo_sign']
   gpgcheck node['cloudstack']['repo_sign'].empty? ? false : true
   action :create

--- a/recipes/repo_rhel.rb
+++ b/recipes/repo_rhel.rb
@@ -22,6 +22,7 @@ include_recipe 'yum'
 yum_repository 'cloudstack' do
   description 'Apache Cloudstack'
   baseurl node['cloudstack']['repo_url']
+  enabled node['cloudstack']['repo_enabled']
   gpgkey node['cloudstack']['repo_sign']
   gpgcheck node['cloudstack']['repo_sign'].empty? ? false : true
   action :create

--- a/templates/default/cloudstack.cnf.erb
+++ b/templates/default/cloudstack.cnf.erb
@@ -3,4 +3,5 @@ innodb_rollback_on_timeout = <%= @innodb_rollback_on_timeout %>
 innodb_lock_wait_timeout   = <%= @innodb_lock_wait_timeout %>
 max_connections            = <%= @max_connections %>
 log-bin                    = mysql-bin
+server-id                  = 1
 binlog-format              = 'ROW'


### PR DESCRIPTION
- This is to disable it on the environment or node level to prevent
`yum update` accidentally update cloudstack packages and let the
`chef-client` always disable it and manually get enabled (by editting
the repo file on the server) when cloudstack acutally needs to be
updated.
- Add server-id to mysqld conf
- Add default cloudstack repo `metadata_expire` to 5 hours.