### PR TITLE
Fix version typo in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@ cloudstack CHANGELOG
 
 This file is used to list changes made in each version of the co-cloudstack cookbook.
 
-4.1.3
+5.0.0
 -----
 - pdion891 - update default version to 4.11.
+- khos2ow - fixed cookstyle and foodcritic issues.
 
 4.1.2
 -----


### PR DESCRIPTION
It should be `5.0.0` and not `4.1.3`.
/cc @pdion891 