### PR TITLE
Add default SystemVM URL for cloudstack 4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ cloudstack CHANGELOG
 
 This file is used to list changes made in each version of the co-cloudstack cookbook.
 
+6.0.1
+-----
+- khos2ow - Add missing SystemVM URLs for CloudStack 4.10
+
 6.0.0
 -----
 - pdion891 - Fix Chef14 issues on CentOS 7 for cloudstack_setup_database ressource.

--- a/attributes/systemvm_template.rb
+++ b/attributes/systemvm_template.rb
@@ -32,6 +32,15 @@ when '4.11'
     'hyperv'    => 'http://download.cloudstack.org/systemvm/4.11/systemvmtemplate-4.11.1-hyperv.vhd.zip',
     'ovm3'      => 'http://download.cloudstack.org/systemvm/4.11/systemvmtemplate-4.11.1-ovm.raw.bz2',
   }
+when '4.10'
+  default['cloudstack']['systemvm'] = {
+    'xenserver' => 'http://download.cloudstack.org/systemvm/4.10/systemvm64template-4.10-4.10.0.0-xen.vhd.bz2',
+    'vmware'    => 'http://download.cloudstack.org/systemvm/4.10/systemvm64template-4.10-4.10.0.0-vmware.ova',
+    'kvm'       => 'http://download.cloudstack.org/systemvm/4.10/systemvm64template-4.10-4.10.0.0-kvm.qcow2.bz2',
+    'lxc'       => 'http://download.cloudstack.org/systemvm/4.10/systemvm64template-4.10-4.10.0.0-kvm.qcow2.bz2',
+    'hyperv'    => 'http://download.cloudstack.org/systemvm/4.10/systemvm64template-4.10-4.10.0.0-hyperv.vhd.zip',
+    'ovm3'      => 'http://download.cloudstack.org/systemvm/4.10/systemvm64template-4.10-4.10.0.0-ovm.raw.bz2',
+  }
 when '4.6', '4.7', '4.8', '4.9'
   default['cloudstack']['systemvm'] = {
     'xenserver' => 'http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-xen.vhd.bz2',

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'pdion@cloud.ca'
 license          'Apache-2.0'
 description      'Installs/Configures cloudstack'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '6.0.0'
+version          '6.0.1'
 
 source_url       'https://github.com/cloudops/cookbook_cloudstack'
 issues_url       'https://github.com/cloudops/cookbook_cloudstack/issues'


### PR DESCRIPTION
Default SystemVM URLs for CloudStack 4.10 were missing.